### PR TITLE
Created article view count based subscription type. Added migration. …

### DIFF
--- a/src/SubscriptionsModule.php
+++ b/src/SubscriptionsModule.php
@@ -234,6 +234,14 @@ class SubscriptionsModule extends CrmModule
                 \Crm\ApiModule\Authorization\BearerTokenAuthorization::class
             )
         );
+
+        $apiRoutersContainer->attachRouter(
+            new ApiRoute(
+                new ApiIdentifier('1', 'article', 'view'),
+                \Crm\CountSubscriptionModule\Api\v1\SubsctiptionUpdateOnArticelViewHandler::class,
+                \Crm\UsersModule\Auth\UserTokenAuthorization::class
+            )
+        );
     }
 
     public function registerUserData(UserDataRegistrator $dataRegistrator)

--- a/src/SubscriptionsModule.php
+++ b/src/SubscriptionsModule.php
@@ -238,7 +238,7 @@ class SubscriptionsModule extends CrmModule
         $apiRoutersContainer->attachRouter(
             new ApiRoute(
                 new ApiIdentifier('1', 'article', 'view'),
-                \Crm\CountSubscriptionModule\Api\v1\SubsctiptionUpdateOnArticelViewHandler::class,
+                \Crm\SubscriptionsModule\Api\v1\SubsctiptionUpdateOnArticelViewHandler::class,
                 \Crm\UsersModule\Auth\UserTokenAuthorization::class
             )
         );

--- a/src/api/v1/SubsctiptionUpdateOnArticelViewHandler.php
+++ b/src/api/v1/SubsctiptionUpdateOnArticelViewHandler.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Crm\SubscriptionsModule\Api\v1;
+
+use Crm\ApiModule\Api\ApiHandler;
+use Crm\ApiModule\Api\JsonResponse;
+use Crm\ApiModule\Authorization\ApiAuthorizationInterface;
+use Crm\ApiModule\Params\InputParam;
+use Crm\ApiModule\Params\ParamsProcessor;
+use Crm\SubscriptionsModule\Repository\SubscriptionsRepository;
+use Nette\Http\Response;
+use Nette\Utils\DateTime;
+
+class SubsctiptionUpdateOnArticelViewHandler extends ApiHandler
+{
+    private $subscriptionsRepository;
+
+    public function __construct(
+        SubscriptionsRepository $subscriptionsRepository
+    ) {
+        $this->subscriptionsRepository = $subscriptionsRepository;
+    }
+
+    public function params()
+    {
+        return [
+            new InputParam(InputParam::TYPE_POST, 'url', InputParam::REQUIRED),
+        ];
+    }
+
+    public function handle(ApiAuthorizationInterface $authorization) {
+        $data = $authorization->getAuthorizedData();
+        if (!isset($data['token'])) {
+            $response = new JsonResponse(['status' => 'error', 'message' => 'Cannot authorize user']);
+            $response->setHttpCode(Response::S403_FORBIDDEN);
+            return $response;
+        }
+
+        $paramsProcessor = new ParamsProcessor($this->params());
+        $params = $paramsProcessor->getValues();
+
+        $token = $data['token'];
+        $subscription = $this->getActiveSubscription($token->user_id);
+
+        if ($subscription) {
+          $result = $this->countView($subscription, $params['url']);
+        } else {
+          $result = [
+              'status' => 'no_active_subscription',
+          ];
+        }
+
+        $response = new JsonResponse($result);
+        $response->setHttpCode(Response::S200_OK);
+        return $response;
+    }
+
+    private function getActiveSubscription($user_id) {
+        $subscriptions = $this->subscriptionsRepository->userSubscriptions($user_id);
+        $where = [
+          'end_time >= ?' => new DateTime(),
+          'start_time <= ?' => new DateTime()
+        ];
+        $subscriptions->where($where);
+
+        $countSub = false;
+        $timeSub = false;
+
+        foreach ($subscriptions as $sub) {
+
+          $sub_type = $sub->subscription_type;
+          if ($sub_type->code == 'article_count') {
+            $countSub = $sub;
+          } else {
+            $timeSub = $sub;
+          }
+        }
+
+        return $timeSub ? $timeSub : ($countSub ? $countSub : false);
+      }
+
+      private function countView($subscription, $url) {
+        $sub_type = $subscription->subscription_type;
+        $values = $subscription->toArray();
+        if ($sub_type->code == 'article_count') {
+          $viewed_articles = unserialize($values['articles'], ['allowed_classes' => ['array']]);
+
+          if (!is_array($viewed_articles)) {
+            $viewed_articles = [];
+          }
+
+          if (in_array($url, $viewed_articles)) {
+            return [
+              'status' => 'ok',
+              'remaining' => $sub_type->length - count($viewed_articles)
+            ];
+          }
+
+          if (count($viewed_articles) < $sub_type->length) {
+            $viewed_articles[] = $url;
+            $values['articles'] = serialize(array_filter($viewed_articles));
+            $this->subscriptionsRepository->update($subscription, $values);
+            return [
+              'status' => 'ok',
+              'remaining' => $sub_type->length - count($viewed_articles)
+            ];
+          }
+          return [
+            'status' => 'not more articles',
+            'remaining' => $sub_type->length - count($viewed_articles)
+          ];
+        }
+        return [
+          'status' => 'ok',
+        ];
+    }
+
+}

--- a/src/api/v1/SubsctiptionUpdateOnArticelViewHandler.php
+++ b/src/api/v1/SubsctiptionUpdateOnArticelViewHandler.php
@@ -77,41 +77,41 @@ class SubsctiptionUpdateOnArticelViewHandler extends ApiHandler
         }
 
         return $timeSub ? $timeSub : ($countSub ? $countSub : false);
-      }
+    }
 
-      private function countView($subscription, $url) {
+    private function countView($subscription, $url) {
         $sub_type = $subscription->subscription_type;
         $values = $subscription->toArray();
         if ($sub_type->code == 'article_count') {
-          $viewed_articles = unserialize($values['articles'], ['allowed_classes' => ['array']]);
+            $viewed_articles = unserialize($values['articles'], ['allowed_classes' => ['array']]);
 
-          if (!is_array($viewed_articles)) {
-            $viewed_articles = [];
-          }
+            if (!is_array($viewed_articles)) {
+                $viewed_articles = [];
+            }
 
-          if (in_array($url, $viewed_articles)) {
+            if (in_array($url, $viewed_articles)) {
+                return [
+                    'status' => 'ok',
+                    'remaining' => $sub_type->length - count($viewed_articles)
+                ];
+            }
+
+            if (count($viewed_articles) < $sub_type->length) {
+                $viewed_articles[] = $url;
+                $values['articles'] = serialize(array_filter($viewed_articles));
+                $this->subscriptionsRepository->update($subscription, $values);
+                return [
+                    'status' => 'ok',
+                    'remaining' => $sub_type->length - count($viewed_articles)
+                ];
+            }
             return [
-              'status' => 'ok',
-              'remaining' => $sub_type->length - count($viewed_articles)
+                'status' => 'not more articles',
+                'remaining' => $sub_type->length - count($viewed_articles)
             ];
-          }
-
-          if (count($viewed_articles) < $sub_type->length) {
-            $viewed_articles[] = $url;
-            $values['articles'] = serialize(array_filter($viewed_articles));
-            $this->subscriptionsRepository->update($subscription, $values);
-            return [
-              'status' => 'ok',
-              'remaining' => $sub_type->length - count($viewed_articles)
-            ];
-          }
-          return [
-            'status' => 'not more articles',
-            'remaining' => $sub_type->length - count($viewed_articles)
-          ];
         }
         return [
-          'status' => 'ok',
+            'status' => 'ok',
         ];
     }
 

--- a/src/api/v1/UsersSubscriptionsHandler.php
+++ b/src/api/v1/UsersSubscriptionsHandler.php
@@ -71,15 +71,22 @@ class UsersSubscriptionsHandler extends ApiHandler
     private function formatSubscription($subscription, $subscriptionType)
     {
         $access = [];
-        foreach ($subscriptionType->related('content_access')->order('content_access.sorting') as $contentAccess) {
-            $access[] = $contentAccess->content_access->name;
-        }
 
-        return [
+        $formatted_subscription = [
             'start_at' => $subscription->start_time->format('c'),
             'end_at' => $subscription->end_time->format('c'),
             'code' => $subscriptionType->code,
-            'access' => $access,
+            'access' => []
         ];
+
+        foreach ($subscriptionType->related('content_access')->order('content_access.sorting') as $contentAccess) {
+            $formatted_subscription['access'][] = $contentAccess->content_access->name;
+            if ($contentAccess->content_access->name == 'articles') {
+                $viewed_articles = unserialize($subscription->articles);
+                $formatted_subscription['remaining_articles'] = max(0, $subscriptionType->length - count($viewed_articles));
+            }
+        }
+
+        return $formatted_subscription;
     }
 }

--- a/src/config/config.neon
+++ b/src/config/config.neon
@@ -36,6 +36,7 @@ services:
 	- Crm\SubscriptionsModule\Components\SubscriptionEndsStatsFactoryInterface
 	- Crm\SubscriptionsModule\Commands\ChangeSubscriptionsStateCommand
 	- Crm\SubscriptionsModule\Api\v1\UsersSubscriptionsHandler
+	- Crm\SubscriptionsModule\Api\v1\SubsctiptionUpdateOnArticelViewHandler
 	- Crm\SubscriptionsModule\Subscription\ActualUserSubscription
 	- Crm\SubscriptionsModule\Events\AddressRemovedHandler
 	- Crm\SubscriptionsModule\Events\PreNotificationEventHandler
@@ -74,6 +75,7 @@ services:
 		class: Crm\SubscriptionsModule\Length\LengthMethodFactory
 		setup:
 			- registerExtension('fix_days', Crm\SubscriptionsModule\Length\FixDaysLengthMethod())
+			- registerExtension('article_count', Crm\SubscriptionsModule\Length\ArticleCountLengthMethod())
 
 	filterLoader:
 		setup:

--- a/src/forms/SubscriptionFormFactory.php
+++ b/src/forms/SubscriptionFormFactory.php
@@ -69,6 +69,10 @@ class SubscriptionFormFactory
             $defaults = $subscription->toArray();
         }
 
+        $article_list = isset($defaults['articles']) ? unserialize($defaults['articles'], ['allowed_classes' => ['array']]) : [];
+
+        $defaults['articles'] = is_array($article_list) ? implode("\n", $article_list) : "";
+
         $form = new Form;
 
         $form->setRenderer(new BootstrapRenderer());
@@ -121,6 +125,11 @@ class SubscriptionFormFactory
             ->getControlPrototype()
             ->addAttributes(['class' => 'autosize']);
 
+        $form->addTextArea('articles', 'subscriptions.data.subscriptions.fields.articles')
+            ->setAttribute('placeholder', 'subscriptions.data.subscriptions.placeholder.articles')
+            ->getControlPrototype()
+            ->addAttributes(['class' => 'autosize']);
+
         $form->addSelect('address_id', 'subscriptions.data.subscriptions.fields.address_id', $this->addressesRepository->addressesSelect($user, false))
             ->setPrompt('--');
 
@@ -167,6 +176,11 @@ class SubscriptionFormFactory
         $subscriptionType = $this->subscriptionTypesRepository->find($values['subscription_type_id']);
         $user = $this->usersRepository->find($values['user_id']);
 
+        $article_list = preg_split('/\r\n|\r|\n/', $values['articles']);
+
+        $articles = serialize($article_list);
+        $values['articles'] = $articles;
+
         if (isset($values['subscription_id'])) {
             $subscriptionId = $values['subscription_id'];
             unset($values['subscription_id']);
@@ -203,7 +217,8 @@ class SubscriptionFormFactory
                 $startTime,
                 $endTime,
                 $values['note'],
-                $address
+                $address,
+                $articles
             );
             $this->onSave->__invoke($subscription);
         }

--- a/src/lang/subscriptions.en_US.neon
+++ b/src/lang/subscriptions.en_US.neon
@@ -17,6 +17,7 @@ data:
 			note: Note
 			address_id: Address
 			payment: Payment
+			articles: Viewed Articles
 		required:
 			start_time: Start time is required
 			end_time: End time is required
@@ -25,6 +26,7 @@ data:
 			start_time: for example 13.2.2015
 			end_time: for example 13.2.2015
 			note: Your custom note to subscription
+			articles: "List of articles go here, one on each line"
 		errors:
 			end_time_before_start_time: End time must be after start time
 			no_subscription_type_id: No subscription type

--- a/src/migrations/20200124104006_count_subscription_init_migration.php
+++ b/src/migrations/20200124104006_count_subscription_init_migration.php
@@ -1,0 +1,29 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class CountSubscriptionInitMigration extends AbstractMigration
+{
+
+    public function up()
+    {
+        $table = $this->table('subscriptions');
+
+        $exists = $table->hasColumn('articles');
+
+        if (!$exists) {
+            $table->addColumn('articles', 'blob', ['null' => true, 'default' => NULL])->update();
+        }
+    }
+
+    public function down() {
+        $table = $this->table('subscriptions');
+
+        $exists = $table->hasColumn('articles');
+
+        if ($exists) {
+            $table->removeColumn('articles')->save();
+        }
+    }
+
+}

--- a/src/models/Length/ArticleCountLengthMethod.php
+++ b/src/models/Length/ArticleCountLengthMethod.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Crm\SubscriptionsModule\Length;
+
+use DateTime;
+use DateInterval;
+use Nette\Database\Table\IRow;
+use Crm\SubscriptionsModule\Length\Length;
+use Crm\SubscriptionsModule\Length\LengthMethodInterface;
+
+class ArticleCountLengthMethod implements LengthMethodInterface
+{
+    public function getEndTime(DateTime $startTime, IRow $subscriptionType, bool $isExtending): Length
+    {
+        // This type of subscription should last indefinitely,
+        // it ends when the user consumed the set number of articles.
+        $length = 99999;
+        if ($isExtending && $subscriptionType->extending_length) {
+            $length = $subscriptionType->extending_length;
+        }
+        $interval = new DateInterval("P{$length}D");
+        $end = (clone $startTime)->add($interval);
+
+        if ($subscriptionType->fixed_end) {
+            $end = $subscriptionType->fixed_end;
+        }
+
+        return new Length($end, $length);
+    }
+}

--- a/src/seeders/ContentAccessSeeder.php
+++ b/src/seeders/ContentAccessSeeder.php
@@ -39,6 +39,12 @@ class ContentAccessSeeder implements ISeeder
         $class = 'label label-warning';
         $sorting = 300;
         $this->seedContentAccess($name, $description, $class, $sorting);
+
+        $name = 'articles';
+        $description = 'Number of Articles';
+        $class = 'label label-success';
+        $sorting = 100;
+        $this->seedContentAccess($name, $description, $class, $sorting);
     }
 
     private function seedContentAccess($name, $description, $class = '', $sorting = 100)

--- a/src/seeders/SubscriptionLengthMethodSeeder.php
+++ b/src/seeders/SubscriptionLengthMethodSeeder.php
@@ -42,5 +42,18 @@ class SubscriptionLengthMethodSeeder implements ISeeder
         } else {
             $output->writeln("  * subscription extension method <info>{$method}</info> exists");
         }
+
+        $method = 'article_count';
+        if (!$this->subscriptionLengthMethodsRepository->exists($method)) {
+            $this->subscriptionLengthMethodsRepository->add(
+                $method,
+                'Article count',
+                'Calculate subscription length based on number of articles viewed.',
+                300
+            );
+            $output->writeln("  <comment>* subscription extension method <info>{$method}</info> created</comment>");
+        } else {
+            $output->writeln("  * subscription extension method <info>{$method}</info> exists");
+        }
     }
 }


### PR DESCRIPTION
Subscription table has been extended with a field named 'articles', this will store data about the articles the free subscriber has viewed.
A new length method has been created so a new free subscription can be created that will allow access to set number of articles based on the existing length field of a subscription type.
A new content access has been created named 'article count' to distinguish subscription type from regular subscription.
SubscriptionFormFactory class has been extended with an 'article' textarea, so administrators can view the articles a free subscriber has viewed, and edit them if necessary.
A new API callback (/article/view) has been added to count the articles the free subscribers access, or not, if the user exceeded the number of free articles to view.